### PR TITLE
🔼 Update backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [workspace]
 members = [
-    "./aes", 
+    "./aes",
 ]
 
 [dependencies]
@@ -20,15 +20,13 @@ libsodium-sys = "0.2"
 crypto2       = { git = "https://github.com/shadowsocks/crypto2", branch = "dev" }
 
 # RustCrypto
-aes              = "0.6"
-aes-gcm          = "0.8"
-ccm              = "0.3"
-aes-gcm-siv      = "0.9"
-aes-siv          = "0.5"
-chacha20         = "0.6"
-chacha20poly1305 = "0.7"
-
-
+aes              = "0.7"
+aes-gcm          = "0.9"
+ccm              = "0.4"
+aes-gcm-siv      = "0.10"
+aes-siv          = "0.6"
+chacha20         = "0.8"
+chacha20poly1305 = "0.9"
 
 [patch.crates-io]
 aes = { path = './aes' }

--- a/src/RustCrypto.rs
+++ b/src/RustCrypto.rs
@@ -1,5 +1,5 @@
 use aes::{Aes128, Aes256};
-use aes::cipher::{ NewBlockCipher, BlockCipher, NewStreamCipher, StreamCipher };
+use aes::cipher::{NewBlockCipher, BlockEncrypt};
 use aes::cipher::generic_array::GenericArray;
 use aes_gcm::AesGcm;
 use ccm::{Ccm, consts::{U12, U16, U32}};
@@ -8,7 +8,7 @@ use aes_gcm_siv::AesGcmSiv;
 use aes_siv::Aes128SivAead;
 use chacha20::ChaCha20;
 use chacha20poly1305::ChaCha20Poly1305;
-
+use chacha20::cipher::{NewCipher, StreamCipher};
 
 type Aes128Gcm    = AesGcm<Aes128, U12>;
 type Aes256Gcm    = AesGcm<Aes256, U12>;
@@ -19,7 +19,6 @@ type ChaCha20Key           = GenericArray<u8, U32>;
 type ChaCha20Nonce         = GenericArray<u8, U12>;
 type ChaCha20Poly1305Key   = GenericArray<u8, U32>;
 type ChaCha20Poly1305Nonce = GenericArray<u8, U12>;
-
 
 #[bench]
 fn aes_128(b: &mut test::Bencher) {
@@ -240,10 +239,10 @@ fn chacha20(b: &mut test::Bencher) {
             0x9d, 0xca, 0x5c, 0xbc, 0x20, 0x70, 0x75, 0xc0,
             0x1c, 0x92, 0x40, 0xa5, 0xeb, 0x55, 0xd3, 0x8a, 
             0xf3, 0x33, 0x88, 0x86, 0x04, 0xf6, 0xb5, 0xf0,
-            0x47, 0x39, 0x17, 0xc1, 0x40, 0x2b, 0x80, 0x09, 
+            0x47, 0x39, 0x17, 0xc1, 0x40, 0x2b, 0x80, 0x09,
             0x9d, 0xca, 0x5c, 0xbc, 0x20, 0x70, 0x75, 0xc0,
         ]);
-        cipher.encrypt(&mut ciphertext);
+        cipher.apply_keystream(&mut ciphertext);
         ciphertext
     })
 }


### PR DESCRIPTION
Closes #1. cc @str4d.

Test result on Arch Linux `5.15.12-arch1-1.1`, i5-7400, `-Ctarget-cpu=native`:

```
test Crypto2::aes_128               ... bench:          17 ns/iter (+/- 0) = 941 MB/s
test Crypto2::aes_128_ccm           ... bench:          54 ns/iter (+/- 1) = 296 MB/s
test Crypto2::aes_128_gcm           ... bench:          39 ns/iter (+/- 0) = 410 MB/s
test Crypto2::aes_128_gcm_siv       ... bench:         104 ns/iter (+/- 1) = 153 MB/s
test Crypto2::aes_128_ocb_tag_128   ... bench:          64 ns/iter (+/- 2) = 250 MB/s
test Crypto2::aes_128_siv_cmac_256  ... bench:          37 ns/iter (+/- 0) = 432 MB/s
test Crypto2::aes_256               ... bench:          22 ns/iter (+/- 0) = 727 MB/s
test Crypto2::aes_256_gcm           ... bench:          45 ns/iter (+/- 0) = 355 MB/s
test Crypto2::chacha20              ... bench:          90 ns/iter (+/- 1) = 711 MB/s
test Crypto2::chacha20_poly1305     ... bench:         314 ns/iter (+/- 5) = 203 MB/s
test Mbedtls::aes_128               ... bench:          19 ns/iter (+/- 0) = 842 MB/s
test Mbedtls::aes_128_gcm           ... bench:         117 ns/iter (+/- 1) = 136 MB/s
test Mbedtls::aes_256               ... bench:          24 ns/iter (+/- 0) = 666 MB/s
test Mbedtls::aes_256_gcm           ... bench:         127 ns/iter (+/- 2) = 125 MB/s
test Mbedtls::chacha20              ... bench:         163 ns/iter (+/- 3) = 392 MB/s
test Mbedtls::chacha20_poly1305     ... bench:         456 ns/iter (+/- 35) = 140 MB/s
test OpenSSL::aes_128               ... bench:          59 ns/iter (+/- 3) = 271 MB/s
test OpenSSL::evp_aes_128           ... bench:          22 ns/iter (+/- 0) = 727 MB/s
test OpenSSL::evp_aes_128_gcm       ... bench:         434 ns/iter (+/- 7) = 36 MB/s
test OpenSSL::evp_aes_128_ocb       ... bench:         478 ns/iter (+/- 5) = 33 MB/s
test OpenSSL::evp_aes_256           ... bench:          27 ns/iter (+/- 0) = 592 MB/s
test OpenSSL::evp_aes_256_gcm       ... bench:         454 ns/iter (+/- 7) = 35 MB/s
test OpenSSL::evp_chacha20          ... bench:         243 ns/iter (+/- 3) = 263 MB/s
test OpenSSL::evp_chacha20_poly1305 ... bench:         456 ns/iter (+/- 9) = 140 MB/s
test Ring::aes_128_gcm              ... bench:          88 ns/iter (+/- 5) = 181 MB/s
test Ring::aes_256_gcm              ... bench:          98 ns/iter (+/- 2) = 163 MB/s
test Ring::chacha20_poly1305        ... bench:         159 ns/iter (+/- 1) = 402 MB/s
test RustCrypto::aes_128            ... bench:          17 ns/iter (+/- 0) = 941 MB/s
test RustCrypto::aes_128_ccm        ... bench:          60 ns/iter (+/- 1) = 266 MB/s
test RustCrypto::aes_128_gcm        ... bench:          51 ns/iter (+/- 0) = 313 MB/s
test RustCrypto::aes_128_gcm_siv    ... bench:         198 ns/iter (+/- 6) = 80 MB/s
test RustCrypto::aes_256            ... bench:          22 ns/iter (+/- 0) = 727 MB/s
test RustCrypto::aes_256_gcm        ... bench:          58 ns/iter (+/- 0) = 275 MB/s
test RustCrypto::aes_siv_cmac_256   ... bench:         308 ns/iter (+/- 6) = 51 MB/s
test RustCrypto::chacha20           ... bench:         162 ns/iter (+/- 2) = 395 MB/s
test RustCrypto::chacha20_poly1305  ... bench:         470 ns/iter (+/- 9) = 136 MB/s
test Sodium::aes_256_gcm            ... bench:         167 ns/iter (+/- 2) = 95 MB/s
test Sodium::chacha20_poly1305      ... bench:         326 ns/iter (+/- 4) = 196 MB/s
```